### PR TITLE
Upgrade to Tomcat 9.0.107 while maintaining Java 8 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
+# Dependencies directory (downloaded by build scripts)
 dependencies/
+
+# Generated WAR files from extract-patched-war.sh
+*.war
+jabaws-patched*.war
+
+# Build artifacts
+*.o
+*.a
+*.so
+*.deps
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 ################################################################################
-# JABAWS 2.2 — multi‑stage Docker build
+# JABAWS 2.2 — multi‑stage Docker build with Tomcat 9
 #
 # Stage layout
 # ─────────────
 # 1. tool-builder   – build every native binary (clustal*, mafft, etc.)
 # 2. war-patcher    – unpack WAR, drop in patched config + binaries, re‑jar
-# 3. runtime        – slim Tomcat image that serves either the WAR or its
-#                     exploded directory
+# 3. runtime        – Tomcat 9.0.107 with Java 8 (JABAWS compatibility)
 ################################################################################
 
 ############################
@@ -127,7 +126,7 @@ RUN jar cf /tmp/jabaws-patched.war -C . .
 ############################
 # Stage 3 – slim Tomcat runtime
 ############################
-FROM tomcat:8.5.100-jre8-temurin-jammy
+FROM tomcat:9.0.107-jre8-temurin-jammy
 
 # ---- bring in the runtime libs the native tools need (and Python 2) ----
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ open http://localhost:8080/jabaws                         # Access
 Multi-stage Docker approach:
 1. **tool-builder** – compiles native bioinformatics tools
 2. **war-patcher** – injects binaries into the WAR file
-3. **runtime** – slim Tomcat with patched WAR
+3. **runtime** – Tomcat 9.0.107 with Java 8 (JABAWS compatibility)
 
 Ensures cross-platform builds and clean runtimes.
 
@@ -158,5 +158,5 @@ Ensures cross-platform builds and clean runtimes.
 
 ## ✅ Verified On
 - macOS (Apple Silicon) via Docker Desktop
-- Tomcat 8.5 with Java 8
+- Tomcat 9.0.107 with Java 8 (JABAWS compatibility)
 - Included tools compiled per platform


### PR DESCRIPTION
## Overview
This PR upgrades the JABAWS Docker build from Tomcat 8.5.100 to Tomcat 9.0.107 while maintaining Java 8 compatibility for JABAWS.

## Changes Made
- **Upgraded Tomcat version**:  `tomcat:8.5.100-jre8-temurin-jammy` → `tomcat:9.0.107-jre8-temurin-jammy`
- **Maintained Java 8**: Essential for JABAWS compatibility
- **Updated documentation**: Dockerfile comments and README.md reflect the Tomcat 9 upgrade
- **Enhanced .gitignore**: Added patterns to exclude generated WAR files and build artifacts

## Testing Results ✅
- **All services show green lights** on the JABAWS status page
- **All services tested successfully** from Jalview with test jobs

## Benefits
- **Modern Tomcat version** with latest security updates and performance improvements

## Technical Details
The upgrade affects only the final runtime stage (`Stage 3`) of the multi-stage Docker build:
- Tool compilation (Stage 1) remains unchanged
- WAR patching (Stage 2) remains unchanged  
- Runtime (Stage 3) now uses Tomcat 9.0.107 with Java 8